### PR TITLE
MAINT: update symbol lookup errors in AssetFinder

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """
 Tests for the zipline.assets package
 """

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -887,7 +887,7 @@ class AssetFinder(object):
                 # there was only one exact match
                 return options[0]
 
-             # there is more than one exact match for this fuzzy symbol
+            # there is more than one exact match for this fuzzy symbol
             raise MultipleSymbolsFoundForFuzzySymbol(
                 symbol=symbol,
                 options=self.retrieve_all(owner.sid for owner in owners),

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -819,9 +819,8 @@ class AssetFinder(object):
             if len(owners) == 1:
                 return self.retrieve_asset(owners[0].sid)
 
-            options = set(map(
-                compose(self.retrieve_asset, attrgetter('sid')), owners
-            ))
+            options = {self._retrieve_asset(owner.sid) for owner in owners}
+
             if multi_country:
                 country_codes = set(map(attrgetter('country_code'), options))
 

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -819,7 +819,7 @@ class AssetFinder(object):
             if len(owners) == 1:
                 return self.retrieve_asset(owners[0].sid)
 
-            options = {self._retrieve_asset(owner.sid) for owner in owners}
+            options = {self.retrieve_asset(owner.sid) for owner in owners}
 
             if multi_country:
                 country_codes = set(map(attrgetter('country_code'), options))

--- a/zipline/assets/assets.py
+++ b/zipline/assets/assets.py
@@ -888,7 +888,7 @@ class AssetFinder(object):
                 # there was only one exact match
                 return options[0]
 
-            # there are more than one exact match for this fuzzy symbol
+             # there is more than one exact match for this fuzzy symbol
             raise MultipleSymbolsFoundForFuzzySymbol(
                 symbol=symbol,
                 options=self.retrieve_all(owner.sid for owner in owners),

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -315,6 +315,33 @@ Possible options: {options}
     """.strip()
 
 
+class MultipleSymbolsFoundForFuzzySymbol(ZiplineError):
+    """
+    Raised when a fuzzy symbol lookup is not resolvable without additional
+    information.
+    """
+    msg = dedent("""\
+        Multiple symbols were found fuzzy matching the name '{symbol}'. Use
+        the as_of_date and/or country_code arguments to to specify the date
+        and country for the symbol-lookup.
+
+        Possible options: {options}
+    """)
+
+
+class SameSymbolUsedAcrossCountries(ZiplineError):
+    """
+    Raised when a symbol() call contains a symbol that is used in more than
+    one country and is thus not resolvable without a country_code.
+    """
+    msg = dedent("""\
+        The symbol '{symbol}' is used in more than one country. Use the
+        country_code' argument to to specify the country.
+
+        Possible options: {options}
+    """)
+
+
 class SymbolNotFound(ZiplineError):
     """
     Raised when a symbol() call contains a non-existant symbol.

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -338,7 +338,7 @@ class SameSymbolUsedAcrossCountries(MultipleSymbolsFound):
         The symbol '{symbol}' is used in more than one country. Use the
         country_code argument to to specify the country.
 
-        Possible options: {options}
+        Possible options by country: {options}
     """)
 
 

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -336,7 +336,7 @@ class SameSymbolUsedAcrossCountries(ZiplineError):
     """
     msg = dedent("""\
         The symbol '{symbol}' is used in more than one country. Use the
-        country_code' argument to to specify the country.
+        country_code argument to to specify the country.
 
         Possible options: {options}
     """)

--- a/zipline/errors.py
+++ b/zipline/errors.py
@@ -315,7 +315,7 @@ Possible options: {options}
     """.strip()
 
 
-class MultipleSymbolsFoundForFuzzySymbol(ZiplineError):
+class MultipleSymbolsFoundForFuzzySymbol(MultipleSymbolsFound):
     """
     Raised when a fuzzy symbol lookup is not resolvable without additional
     information.
@@ -329,7 +329,7 @@ class MultipleSymbolsFoundForFuzzySymbol(ZiplineError):
     """)
 
 
-class SameSymbolUsedAcrossCountries(ZiplineError):
+class SameSymbolUsedAcrossCountries(MultipleSymbolsFound):
     """
     Raised when a symbol() call contains a symbol that is used in more than
     one country and is thus not resolvable without a country_code.


### PR DESCRIPTION
- raise a `SameSymbolUsedAcrossCountries` if multiple assets across countries share the same symbol
- raise a `MultipleSymbolsFoundForFuzzySymbol` if multiple symbols are found when `fuzzy=True` is passed